### PR TITLE
Update SSL-checking for Let's Encrypt.

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,13 +329,25 @@ Existing alternatives:
 ssl-expiry-date
 ----------------
 
-Report the date, and number of days, until the given SSL certificate expires.
+Report the date, and number of days, until the given SSL certificate
+expires.  Multiple domain-names may be accepted and each is tested
+in turn.
+
+The default output is "noisy", but you may add "-d" to simplify this
+to the domain-name and the number of days remaining on the certificate.
+
 
 Example:
 
-        ./ssl-expiry-date bbc.co.uk
-        Certificate presented at : bbc.co.uk
-        Expires: Jun 18 13:50:58 2013 GMT  [63 days in the future]
+      ./ssl-expiry-date  bbc.co.uk
+      bbc.co.uk
+          Expires: Sep 18 13:50:57 2016 GMT
+          Days: 266
+
+      ./ssl-expiry-date -d bbc.co.uk steve.org.uk
+      bbc.co.uk: 266
+      steve.org.uk: 82
+
 
 
 

--- a/ssl-expiry-date
+++ b/ssl-expiry-date
@@ -8,7 +8,7 @@
 # License
 # -------
 #
-# Copyright (c) 2013 by Steve Kemp.  All rights reserved.
+# Copyright (c) 2013-2015 by Steve Kemp.  All rights reserved.
 #
 # This script is free software; you can redistribute it and/or modify it under
 # the same terms as Perl itself.
@@ -19,97 +19,123 @@
 
 
 #
-#  Get the name to test
+#  Simple function to show usage information, and exit.
 #
-name=$1
-
-if [ -z "$name" ]; then
-   echo "Usage: $0 some.host.name [portnumber|servicename]"
-   exit 3
-fi
-
-#
-#  Get ssl port or set default to https
-#
-port=${2}
-
-if [ -z "$port" ]; then
-   port=443
-fi
-
+usage () {
+    echo "Usage: $0 [-d] [-p 443] domain1.org domain2.com .. domainN"
+    exit 0
+}
 
 
 #
+#  Default settings for flags set by the command-line arguments
 #
+days=0
+port=443
+
 #
-if ( ! which openssl >/dev/null 2>/dev/null );  then
-   echo "You do not have the 'openssl' tool installed"
-   exit 2
-fi
+#  Parse the argument(s) - i.e. look for "-d" / "-p 443".
+#
+while getopts "h?dp:" opt; do
+    case $opt in
+        h)
+            usage
+            ;;
+        \?)
+            usage
+            ;;
+        d)
+            days=1
+            ;;
+        p)
+            port=$OPTARG
+            ;;
+    esac
+done
+shift $((OPTIND-1))
 
 
 #
-#  Make a temporary file
+#  Ensure we have some arguments
 #
-# Test if we have BSD or GNU version of mktemp
-if ( strings $(which mktemp) | grep -q GNU); then
-   #We have the GNU version
-   tmp=$(mktemp)
-else
-  #We have the BSD version
-   tmp=$(mktemp -t tmp)
-fi
-
-
-#
-#  Download the certificate
-#
-if ( ! echo "" | openssl s_client -connect $name:$port > $tmp 2>/dev/null ); then
-   echo "Failed to get cert from https://$name:$port/"
-   exit 3
+if [ "$#" = "0" ]; then
+    usage
 fi
 
 
 #
-#  Get the expiry date
+# For each domain-name on the command-line.
 #
-date=$(openssl x509 -in "$tmp" -noout -enddate | awk -F= '{print $2}')
-
-#
-#  Remove the temporary file
-#
-rm -f "$tmp"
+for name in "$@" ; do
 
 
-#
-#  Convert the expiry date + todays date to seconds-past epoch
-#
-# Check if we have the BSD or the GNU version of date
-if (strings $(which date) | grep -q GNU); then
-  # We have GNU this is easy
-  then=$(date --date "$date" +%s)
-else
-  # We have BSD now it is getting complicated
-  year=$(echo $date | awk '{print $4}')
-  month=$(echo $date | awk '{print $1}')
-  day=$(echo $date | awk '{print $2}')
-  hour=$(echo $date | awk '{print $3}' | awk -F: '{print $1}')
-  minute=$(echo $date | awk '{print $3}' | awk -F: '{print $2}')
-  second=$(echo $date | awk '{print $3}' | awk -F: '{print $3}')
-  then=$(date -v${year}y -v${month} -v${day}d -v${hour}H -v${minute}M -v${second}S -u +%s)
-fi
+    #
+    #  Make a temporary file
+    #
+    # Test if we have BSD or GNU version of mktemp
+    if ( strings $(which mktemp) | grep -q GNU); then
+        # We have the GNU version
+        tmp=$(mktemp)
+    else
+        # We have the BSD version
+        tmp=$(mktemp -t tmp)
+    fi
 
-now=$(date +%s)
 
-#
-#  Day diff
-#
-diff=$(expr "$then" - "$now" )
-diff=$(expr $diff / 86400 )
+    #
+    #  Download the certificate
+    #
+    if ( ! echo "" | openssl s_client -connect $name:$port > $tmp 2>/dev/null ); then
+        echo "Failed to get cert from https://$name:$port/"
+        exit 3
+    fi
 
-#
-#  All done
-#
-echo "Certificate presented at : $name"
-echo "Expires: $date  [$diff days in the future]"
 
+    #
+    #  Get the expiry date
+    #
+    date=$(openssl x509 -in "$tmp" -noout -enddate | awk -F= '{print $2}')
+
+    #
+    #  Remove the temporary file
+    #
+    rm -f "$tmp"
+
+
+    #
+    #  Convert the expiry date + todays date to seconds-past epoch
+    #
+    # Check if we have the BSD or the GNU version of date
+    if (strings $(which date) | grep -q GNU); then
+        # We have GNU this is easy
+        then=$(date --date "$date" +%s)
+    else
+        # We have BSD now it is getting complicated
+        year=$(echo $date | awk '{print $4}')
+        month=$(echo $date | awk '{print $1}')
+        day=$(echo $date | awk '{print $2}')
+        hour=$(echo $date | awk '{print $3}' | awk -F: '{print $1}')
+        minute=$(echo $date | awk '{print $3}' | awk -F: '{print $2}')
+        second=$(echo $date | awk '{print $3}' | awk -F: '{print $3}')
+        then=$(date -v${year}y -v${month} -v${day}d -v${hour}H -v${minute}M -v${second}S -u +%s)
+    fi
+
+    now=$(date +%s)
+
+    #
+    #  Day diff
+    #
+    diff=$(expr "$then" - "$now" )
+    diff=$(expr $diff / 86400 )
+
+    #
+    #  All done
+    #
+    if [ "$days" = "1" ]; then
+        echo "${name}: ${diff}"
+    else
+        echo "$name"
+        echo "    Expires: ${date}"
+        echo "    Days: ${diff}"
+    fi
+done


### PR DESCRIPTION
Now that I'm using Let's encrypt I have a lot of SSL-certificates
to check - so this update changes the `ssl-expiry-date` test to
allow testing multiple domains at once.

Because we've switched from:

```
    ssl-expiry-date $host $port
```

To:

```
    ssl-expiry-date $host1 $host2  .. $hostN
```

We've now had to add getopt-based parsing to specify a different
port, which is achived via "`-p 1234`".  We've also added a simpler
output which is just "`$domain: $days`".
